### PR TITLE
FIX: Ajusta configuração do Hibernate para ignorar tabelas inexistentes durante o build no Render

### DIFF
--- a/src/test/resources/application-test.properties
+++ b/src/test/resources/application-test.properties
@@ -1,6 +1,10 @@
-# Configurações para o banco em memória H2
-spring.datasource.url=jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1;NOT_FIXED_ID=TRUE
+# Usa o H2
+spring.datasource.url=jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1
 spring.datasource.driverClassName=org.h2.Driver
 spring.datasource.username=sa
 spring.datasource.password=
+
+# Configurações de JPA para o teste
 spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
+spring.jpa.hibernate.ddl-auto=create-drop
+spring.jpa.show-sql=true


### PR DESCRIPTION
Ajusta a configuração do Hibernate para evitar que o processo de build no Render falhe ao procurar tabelas que não existem no ambiente de deploy.

- Desabilita validação automática de tabelas durante o build
- Garante compatibilidade com o ambiente do Render, onde nem todas as tabelas estão disponíveis
- Melhora estabilidade do deploy

Closes #27