### PR TITLE
FEAT: Novo endpoint Observações

### DIFF
--- a/src/main/java/com/odetto/controller/ObservationController.java
+++ b/src/main/java/com/odetto/controller/ObservationController.java
@@ -2,6 +2,7 @@ package com.odetto.controller;
 
 import com.odetto.dto.Observation.ObservationRequestDTO;
 import com.odetto.dto.Observation.ObservationResponseDTO;
+import com.odetto.projection.ObservationProjection;
 import jakarta.validation.Valid;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.http.ResponseEntity;
@@ -21,8 +22,14 @@ public class ObservationController {
     }
 
     @GetMapping("/list-observation-by-enrollment/{enrollment}/{subjectId}")
-    public ResponseEntity<List<ObservationResponseDTO>>listObservationByEnrollment(@PathVariable Long enrollment,@PathVariable Long subjectId) {
-        List<ObservationResponseDTO> observations = observationService.listObservationsByEnrollment(enrollment,subjectId);
+    public ResponseEntity<List<ObservationResponseDTO>>listObservationByEnrollmentAndSubject(@PathVariable Long enrollment,@PathVariable Long subjectId) {
+        List<ObservationResponseDTO> observations = observationService.listObservationsByEnrollmentAndSubject(enrollment,subjectId);
+        return ResponseEntity.ok(observations);
+    }
+
+    @GetMapping("/list-observation-by-enrollment/{enrollment}")
+    public ResponseEntity<List<ObservationProjection>>listObservationByEnrollment2(@PathVariable Long enrollment) {
+        List<ObservationProjection> observations = observationService.listObservationsByEnrollment2(enrollment);
         return ResponseEntity.ok(observations);
     }
 

--- a/src/main/java/com/odetto/projection/ObservationProjection.java
+++ b/src/main/java/com/odetto/projection/ObservationProjection.java
@@ -1,0 +1,8 @@
+package com.odetto.projection;
+
+public interface ObservationProjection {
+    Long getId();
+    String getTeacherName();
+    String getSubject();
+    String getObservation();
+}

--- a/src/main/java/com/odetto/repository/ObservationsRepository.java
+++ b/src/main/java/com/odetto/repository/ObservationsRepository.java
@@ -1,6 +1,7 @@
 package com.odetto.repository;
 
 import com.odetto.model.Observations;
+import com.odetto.projection.ObservationProjection;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
@@ -9,6 +10,13 @@ import java.util.List;
 public interface ObservationsRepository extends JpaRepository<Observations, Long> {
         @Query(value = "select o.* from observations o\n" +
                 "where o.id_subject = :subjectId and o.enrollment_student = :enrollment", nativeQuery = true)
-    List<Observations> FindByStudentEnrollment(Long enrollment, Long subjectId);
+    List<Observations> findByStudentEnrollmentAndSubject(Long enrollment, Long subjectId);
 
+        @Query(value = """
+        SELECT o.id AS id, t.name AS teacherName, s.name AS subject, o.observation AS observation FROM observations o
+        JOIN teacher t ON o.cpf_teacher = t.cpf
+        JOIN subject s ON o.id_subject = s.id
+        WHERE o.enrollment_student = :enrollment
+    """, nativeQuery = true)
+    List<ObservationProjection> findByStudentEnrollment(Long enrollment);
 }

--- a/src/main/java/com/odetto/service/ObservationSevice.java
+++ b/src/main/java/com/odetto/service/ObservationSevice.java
@@ -3,6 +3,7 @@ package com.odetto.service;
 import com.odetto.dto.Observation.ObservationRequestDTO;
 import com.odetto.dto.Observation.ObservationResponseDTO;
 import com.odetto.model.Observations;
+import com.odetto.projection.ObservationProjection;
 import com.odetto.repository.ObservationsRepository;
 import org.springframework.stereotype.Service;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -19,13 +20,22 @@ public class ObservationSevice {
         this.objectMapper = objectMapper;
     }
 
-    public List<ObservationResponseDTO> listObservationsByEnrollment(Long enrollment, Long subjectId) {
-        List<Observations> observations = observationRepository.FindByStudentEnrollment(enrollment, subjectId);
+    public List<ObservationResponseDTO> listObservationsByEnrollmentAndSubject(Long enrollment, Long subjectId) {
+        List<Observations> observations = observationRepository.findByStudentEnrollmentAndSubject(enrollment, subjectId);
         if (observations.isEmpty()) {
             throw new NoSuchElementException("Nenhuma observação encontrada para o aluno com matrícula " + enrollment);
         }
         return observations.stream()
                 .map(observation -> objectMapper.convertValue(observation, ObservationResponseDTO.class))
+                .toList();
+    }
+
+    public List<ObservationProjection> listObservationsByEnrollment2(Long enrollment) {
+        List<ObservationProjection> observations = observationRepository.findByStudentEnrollment(enrollment);
+        if (observations.isEmpty()) {
+            throw new NoSuchElementException("Nenhuma observação encontrada para o aluno com matrícula " + enrollment);
+        }
+        return observations.stream()
                 .toList();
     }
 


### PR DESCRIPTION
Criação  de um novo endpoint que busca observações apenas pela matrícula do aluno.
O que foi criado:
- Nova query para o banco no repository de observações
- Novas funções no service e controller de observações
- Nova projection de observações

Closes #35 