### PR TITLE
FIX: Ajustes Login

### DIFF
--- a/src/main/java/com/odetto/controller/AuthController.java
+++ b/src/main/java/com/odetto/controller/AuthController.java
@@ -2,6 +2,7 @@ package com.odetto.controller;
 
 import com.odetto.dto.LoginRequestDTO;
 import com.odetto.dto.Student.StudentLoginResponseDTO;
+import com.odetto.dto.Teacher.TeacherRequestDTO;
 import com.odetto.dto.Teacher.TeacherResponseDTO;
 import com.odetto.model.Student;
 import com.odetto.model.Teacher;
@@ -30,13 +31,23 @@ public class AuthController {
         Long cpf = request.getCpf();
         String password = request.getPassword();
 
-        Optional<TeacherResponseDTO> teacherOpt = teacherService.getTeacher(cpf);
+        Optional<TeacherRequestDTO> teacherOpt = teacherService.getTeacher(cpf);
         if (teacherOpt.isPresent()) {
-            TeacherResponseDTO teacher = teacherOpt.get();
+            TeacherRequestDTO teacher = teacherOpt.get();
+
             if (teacher.getPassword() == null || !teacher.getPassword().equals(password)) {
                 return ResponseEntity.status(401).body("Senha incorreta para professor.");
             }
-            return ResponseEntity.ok(teacher);
+
+            TeacherResponseDTO teacherResponse = new TeacherResponseDTO(
+                    String.valueOf(teacher.getCpf()),
+                    teacher.getName(),
+                    teacher.getUsername(),
+                    teacher.getHireDate(),
+                    teacher.getSubject()
+            );
+
+            return ResponseEntity.ok(teacherResponse);
         }
 
         Optional<Student> studentOpt = studentService.findStudentByCpf(cpf);

--- a/src/main/java/com/odetto/controller/TeacherController.java
+++ b/src/main/java/com/odetto/controller/TeacherController.java
@@ -1,5 +1,6 @@
 package com.odetto.controller;
 
+import com.odetto.dto.Teacher.TeacherRequestDTO;
 import com.odetto.dto.Teacher.TeacherResponseDTO;
 import com.odetto.service.TeacherService;
 import org.springframework.http.ResponseEntity;
@@ -22,17 +23,40 @@ public class TeacherController {
 
     @GetMapping("/list-teachers")
     public ResponseEntity<List<TeacherResponseDTO>> listTeachers() {
-        List<TeacherResponseDTO> teachers = teacherService.listTeachers();
-        return ResponseEntity.ok(teachers);
+        List<TeacherRequestDTO> teacherRequests = teacherService.listTeachers();
+
+        List<TeacherResponseDTO> responses = teacherRequests.stream()
+                .map(t -> new TeacherResponseDTO(
+                        String.valueOf(t.getCpf()),
+                        t.getName(),
+                        t.getUsername(),
+                        t.getHireDate(),
+                        t.getSubject()
+                ))
+                .toList();
+
+        return ResponseEntity.ok(responses);
     }
+
 
     @GetMapping("/get-teacher-by-cpf/{cpf}")
     public ResponseEntity<TeacherResponseDTO> getTeacherByCpf(@PathVariable Long cpf) {
-        Optional<TeacherResponseDTO> teacherOpt = teacherService.getTeacher(cpf);
+        Optional<TeacherRequestDTO> teacherOpt = teacherService.getTeacher(cpf);
         if (teacherOpt.isEmpty()) {
-            return ResponseEntity.status(404).body(null); // ou mensagem custom
+            return ResponseEntity.status(404).body(null);
         }
-        return ResponseEntity.ok(teacherOpt.get());
+
+        TeacherRequestDTO teacher = teacherOpt.get();
+
+        TeacherResponseDTO teacherResponse = new TeacherResponseDTO(
+                String.valueOf(teacher.getCpf()),
+                teacher.getName(),
+                teacher.getUsername(),
+                teacher.getHireDate(),
+                teacher.getSubject()
+        );
+
+        return ResponseEntity.ok(teacherResponse);
     }
 
 

--- a/src/main/java/com/odetto/dto/Teacher/TeacherRequestDTO.java
+++ b/src/main/java/com/odetto/dto/Teacher/TeacherRequestDTO.java
@@ -9,4 +9,5 @@ public class TeacherRequestDTO {
     private String username;
     private String password;
     private String hireDate;
+    String subject;
 }

--- a/src/main/java/com/odetto/dto/Teacher/TeacherResponseDTO.java
+++ b/src/main/java/com/odetto/dto/Teacher/TeacherResponseDTO.java
@@ -4,8 +4,9 @@ import lombok.Value;
 
 @Value
 public class TeacherResponseDTO {
+    String cpf;
     String name;
     String username;
-    String password;
     String hireDate;
+    String subject;
 }

--- a/src/main/java/com/odetto/projection/TeacherProjection.java
+++ b/src/main/java/com/odetto/projection/TeacherProjection.java
@@ -1,0 +1,10 @@
+package com.odetto.projection;
+
+public interface TeacherProjection {
+    String getCpf();
+    String getPassword();
+    String getName();
+    String getUsername();
+    String getHireDate();
+    String getSubject();
+}

--- a/src/main/java/com/odetto/repository/TeacherRepository.java
+++ b/src/main/java/com/odetto/repository/TeacherRepository.java
@@ -1,10 +1,26 @@
 package com.odetto.repository;
 
 import com.odetto.model.Teacher;
+import com.odetto.projection.TeacherProjection;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface TeacherRepository extends JpaRepository<Teacher, Long> {
-    Optional<Teacher> findByCpf(Long cpf);
+    @Query(value = """
+        SELECT t.cpf AS cpf, t.password AS password, t.name AS name, t.username AS username, t.hired_date AS hireDate, s.name AS subject FROM subject_teacher st
+        JOIN teacher t ON st.cpf_teacher = t.cpf
+        JOIN subject s ON st.id_subject = s.id
+        WHERE t.cpf = :cpf
+    """, nativeQuery = true)
+    Optional<TeacherProjection> findByCpf(Long cpf);
+
+    @Query(value = """
+        SELECT t.cpf AS cpf, t.password AS password, t.name AS name, t.username AS username, t.hired_date AS hireDate, s.name AS subject FROM subject_teacher st
+        JOIN teacher t ON st.cpf_teacher = t.cpf
+        JOIN subject s ON st.id_subject = s.id
+    """, nativeQuery = true)
+    List<TeacherProjection> findAllProjected();
 }

--- a/src/main/java/com/odetto/service/TeacherService.java
+++ b/src/main/java/com/odetto/service/TeacherService.java
@@ -1,7 +1,8 @@
 package com.odetto.service;
 
+import com.odetto.dto.LoginRequestDTO;
+import com.odetto.dto.Teacher.TeacherRequestDTO;
 import com.odetto.dto.Teacher.TeacherResponseDTO;
-import com.odetto.model.Teacher;
 import com.odetto.repository.TeacherRepository;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.stereotype.Service;
@@ -19,14 +20,14 @@ public class TeacherService {
         this.objectMapper = objectMapper;
     }
 
-    public Optional<TeacherResponseDTO> getTeacher(Long cpf) {
+    public Optional<TeacherRequestDTO> getTeacher(Long cpf) {
         return teacherRepository.findByCpf(cpf)
-                .map(teacher -> objectMapper.convertValue(teacher, TeacherResponseDTO.class));
+                .map(teacher -> objectMapper.convertValue(teacher, TeacherRequestDTO.class));
     }
 
-    public List<TeacherResponseDTO> listTeachers() {
-        return teacherRepository.findAll().stream()
-                .map(teacher -> objectMapper.convertValue(teacher, TeacherResponseDTO.class))
+    public List<TeacherRequestDTO> listTeachers() {
+        return teacherRepository.findAllProjected().stream()
+                .map(teacher -> objectMapper.convertValue(teacher, TeacherRequestDTO.class))
                 .toList();
     }
 }


### PR DESCRIPTION
Ajustando corpo do retorno do endpoint de login, retornando matéria e cpf do professor e retirando senha. Consequentemente, também foi alterado o corpo do retorno da listagem de professores e da busca por cpf. As 3 requisições retornam os mesmos campos.

Closes #37 